### PR TITLE
Restructure parsing

### DIFF
--- a/bin/iRep
+++ b/bin/iRep
@@ -11,7 +11,6 @@ ctb@berkeley.edu
 # python modules
 import os
 import sys
-import argparse
 
 
 # iRep
@@ -19,55 +18,5 @@ sys.path.append((os.path.dirname(os.path.abspath(__file__)).rsplit('/', 1)[0]))
 import iRep.iRep as iRep
 
 if __name__ == '__main__':
-    desc = '# calculate the Index of Replication (iRep)'
-    parser = argparse.ArgumentParser(description = desc)
-    parser.add_argument(\
-            '-f', nargs = '*', action = 'store', required = True, \
-            help = 'fasta(s)')
-    parser.add_argument(\
-            '-s', nargs = '*', action = 'store', required = True, \
-            help = 'sorted sam file(s) for each sample (e.g.: bowtie2 --reorder)')
-    parser.add_argument(\
-            '-o', required = True, type = str, \
-            help = 'prefix for output files (table and plots)')
-    parser.add_argument(\
-            '--pickle', action = 'store_true', \
-            help = 'save pickle file (optional)')
-    parser.add_argument(\
-            '-mm', required = False, default = 1, type = int, \
-            help = 'max. # of read mismatches allowed (default: 1)')
-    parser.add_argument(\
-            '--sort', action = 'store_true', \
-            help = 'optional - sort the sam file')
-    parser.add_argument(\
-            '-M', default = '100', \
-            help = 'max. memory (GB) for sorting sam (default: 100)')
-    parser.add_argument(\
-            '--no-plot', action = 'store_true', \
-            help = 'do not plot output')
-    parser.add_argument(\
-            '--no-gc-correction', action = 'store_false', \
-            help = 'do not correct coverage for GC bias before calculating iRep')
-    parser.add_argument(\
-            '-ff', action = 'store_true', \
-            help = 'overwrite files')
-    parser.add_argument(\
-            '-t', required = False, default = 6, type = int, \
-            help = 'threads (default: 6)')
-    args = vars(parser.parse_args())
-    args = iRep.validate_args(args)
-    fastas = iRep.open_files(args['f'])
-    sams, mm, sort, sort_b = args['s'], args['mm'], args['sort'], args['M']
-    # generator for mapping
-    mappings = [[s, iRep.filter_mapping(s, mm, sort, sort_b)] for s in sams]
-    # cancel plotting
-    if args['no_plot'] is True:
-        args['plot'] = False
-    # thresholds
-    thresholds = {'min_cov':5, 'min_wins':0.98, 'min_r2':0.90, \
-                    'fragMbp':175, 'GC_min_r2':0.0}
-    # calculate iRep
-    genomes = iRep.iRep(\
-                fastas, mappings, \
-                args['table'], args['pickle'], args['plot'],
-                thresholds, args['no_gc_correction'], args['t'])
+    args = vars(iRep.parse_irep_args(sys.argv[1:]))
+    iRep.main(args)

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+'''
+Testing suite for iRep
+'''
+
+from subprocess import call
+import os
+import shutil
+import glob
+
+import iRep.iRep_filter
+
+def load_data(datum):
+    '''
+    return the system path to the datum requested
+    '''
+
+    if datum == 'test_outdir':
+        loc = os.path.join(str(os.path.dirname(os.path.realpath(__file__))), \
+        'tmp/test_outdir')
+        return loc
+
+    elif datum =='test_genome':
+        loc = os.path.join(str(os.path.dirname(os.path.realpath(__file__))), \
+        '../sample_data/l_gasseri.fna')
+        return loc
+
+    elif datum == 'test_sams':
+        loc = os.path.join(str(os.path.dirname(os.path.realpath(__file__))), \
+        '../sample_data/*.sam')
+        return glob.glob(loc)
+
+    elif datum == 'solution_irep':
+        loc = os.path.join(str(os.path.dirname(os.path.realpath(__file__))), \
+        '../sample_output/test.iRep.tsv')
+        return loc
+
+    else:
+        raise AttributeError("datum {0} is not found".format(datum))
+
+def execute_cmd(cmd, dry=False, shell=False, stdout=None, stderr=None):
+    '''
+    just a wrapper to call commands
+    '''
+
+    devnull = open(os.devnull, 'w')
+    if stdout == None:
+        stdout = devnull
+
+    if stderr == None:
+        stderr = devnull
+
+    if not shell:
+        print(' '.join(cmd))
+        #if not dry: call(cmd, stderr=stderr, stdout=stdout)
+        if not dry: call(cmd)
+
+    else:
+        print(cmd)
+        if not dry: call(cmd, shell=True, stderr=stderr, stdout=stdout)
+
+    return
+
+class TestiRep():
+    '''
+    class to do regression tests of iRep
+    '''
+
+    def setUp(self):
+        self.outdir = load_data('test_outdir')
+        if os.path.exists(self.outdir):
+            shutil.rmtree(self.outdir)
+        os.makedirs(self.outdir)
+
+        self.genome = load_data('test_genome')
+        self.sams = load_data('test_sams')
+        self.irep_solution = load_data('solution_irep')
+
+    def tearDown(self):
+        pass
+
+    def run_all(self):
+        self.setUp()
+
+        self.regression_test()
+
+        self.tearDown()
+
+    def regression_test(self):
+        '''
+        just call iRep as an external script, compare output to sample output
+        '''
+
+        # generate command
+        test_out = os.path.join(self.outdir, 'test.iRep')
+        cmd = ['iRep', '-f', self.genome, '-o', test_out, '-s'] + self.sams
+
+        # run command
+        execute_cmd(cmd)
+
+        # verify output
+        out_pdf = test_out + '.pdf'
+        assert os.stat(out_pdf).st_size > 0
+
+        out_tsv = test_out + '.tsv'
+        assert os.stat(out_tsv).st_size > 0
+
+        sol_tsv = self.irep_solution
+
+        sol_ireps = self.extract_ireps(sol_tsv)
+        test_ireps = self.extract_ireps(out_tsv)
+
+        assert sorted(sol_ireps) == sorted(test_ireps)
+
+    def extract_ireps(self, tsv):
+        '''
+        from the path to the .tsv file, return a list of iRep values
+        '''
+        values = []
+        irep = iRep.iRep_filter.parse_tables([tsv])
+        for genome in irep.keys():
+            for sam in irep[genome].keys():
+                val = irep[genome][sam]['iRep']
+                values.append(float("{0:.2f}".format(val)))
+        return values
+        
+def test_short():
+    '''
+    tests that shouldn't take very long
+    '''
+
+def test_long():
+    '''
+    full test suite (could take a while)
+    '''
+
+    t = TestiRep()
+    t.run_all()
+    return
+
+if __name__ == "__main__":
+    test_short()
+    test_long()
+    print("All tests passed!")


### PR DESCRIPTION
Changed bin/iRep to be much lighter. Instead of having it's own parser, it calls the same parser as the regular iRep program. This way any changes you make to the parser (or the main method) are reflected in both bin/iRep and iRep/iRep.py.

To make this work I had to restructure iRep.py a bit too, but as a benefit you can now call the whole iRep pipeline from other python modules. This is mainly useful for testing :)