### PR TITLE
Bug fix about import fault from command line

### DIFF
--- a/iRep/iRep.py
+++ b/iRep/iRep.py
@@ -31,8 +31,8 @@ from multiprocessing import Pool
 
 # ctb
 #sys.path.append((os.path.dirname(os.path.abspath(__file__)).rsplit('/', 1)[0]))
-from mapped import get_reads as mapped
-from fasta import iterate_fasta as parse_fasta
+from iRep.mapped import get_reads as mapped
+from iRep.fasta import iterate_fasta as parse_fasta
 
 def plot_coverage(cov, trimmed, avg_cov, length, fit, iRep, uiRep, r2, kept_windows, title):
     """


### PR DESCRIPTION
Hello @christophertbrown 

In the current implementation, I couldn't call iRep from command line.

```bash
$ git clone git@github.com:christophertbrown/iRep.git
$ cd iRep
$ pip install .
$ irep
```

```python
Traceback (most recent call last):
  File "/Users/suzukishinya/.pyenv/versions/3.6.2_irep/bin/irep", line 18, in <module>
    import iRep.iRep as iRep
  File "/Users/suzukishinya/.pyenv/versions/3.6.2/envs/3.6.2_irep/lib/python3.6/site-packages/iRep/iRep.py", line 34, in <module>
    from mapped import get_reads as mapped
ModuleNotFoundError: No module named 'mapped'
```

I have fixed this simple import error.